### PR TITLE
Optimize peripheral calls in rednet.run

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/rednet.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/rednet.lua
@@ -403,10 +403,11 @@ function run()
         if sEvent == "modem_message" then
             -- Got a modem message, process it and add it to the rednet event queue
             local sModem, nChannel, nReplyChannel, tMessage = p1, p2, p3, p4
-            if isOpen(sModem) and (nChannel == id_as_channel() or nChannel == CHANNEL_BROADCAST) then
+            if (nChannel == id_as_channel() or nChannel == CHANNEL_BROADCAST) then
                 if type(tMessage) == "table" and type(tMessage.nMessageID) == "number"
                     and tMessage.nMessageID == tMessage.nMessageID and not tReceivedMessages[tMessage.nMessageID]
                     and ((tMessage.nRecipient and tMessage.nRecipient == os.getComputerID()) or nChannel == CHANNEL_BROADCAST)
+                    and isOpen(sModem)
                 then
                     tReceivedMessages[tMessage.nMessageID] = os.clock() + 9.5
                     if not nClearTimer then nClearTimer = os.startTimer(10) end

--- a/src/main/resources/data/computercraft/lua/rom/apis/rednet.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/rednet.lua
@@ -403,7 +403,7 @@ function run()
         if sEvent == "modem_message" then
             -- Got a modem message, process it and add it to the rednet event queue
             local sModem, nChannel, nReplyChannel, tMessage = p1, p2, p3, p4
-            if (nChannel == id_as_channel() or nChannel == CHANNEL_BROADCAST) then
+            if nChannel == id_as_channel() or nChannel == CHANNEL_BROADCAST then
                 if type(tMessage) == "table" and type(tMessage.nMessageID) == "number"
                     and tMessage.nMessageID == tMessage.nMessageID and not tReceivedMessages[tMessage.nMessageID]
                     and ((tMessage.nRecipient and tMessage.nRecipient == os.getComputerID()) or nChannel == CHANNEL_BROADCAST)


### PR DESCRIPTION
Currently, rednet.run will do a peripheral call (.isOpen) every time it receives a modem message on an open port, regarless if rednet.open was called beforehand.

This changes it so that isOpen is run last, after checking that the message is destined to the host, and is a valid rednet formatted message.