### PR TITLE
Clarify term_resize event.

### DIFF
--- a/doc/events/term_resize.md
+++ b/doc/events/term_resize.md
@@ -2,7 +2,9 @@
 module: [kind=event] term_resize
 ---
 
-The @{term_resize} event is fired when the main terminal is resized, mainly when a new tab is opened or closed in @{multishell}.
+The @{term_resize} event is fired when the main terminal is resized, mainly when a new tab is opened or closed in @{multishell} or when the terminal out is being redirected by the "monitor" program and monitor size changes.
+
+This event indicates that there is no guarantee of what is on the screen and where it is located. GUI based software should redraw its contents but simple terminal programs can safely ignore it.
 
 ## Example
 Prints :


### PR DESCRIPTION
Resolves #999

Clarifies what `term_resize` event indicates.
