### PR TITLE
Fix hasTypeRemote not working with additional types. (#1001)

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemPeripheral.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wired/WiredModemPeripheral.java
@@ -151,7 +151,7 @@ public abstract class WiredModemPeripheral extends ModemPeripheral implements IW
     public final Object[] hasTypeRemote( IComputerAccess computer, String name, String type )
     {
         RemotePeripheralWrapper wrapper = getWrapper( computer, name );
-        return wrapper == null ? null : new Object[] { wrapper.getType().equals( type ) || wrapper.getAdditionalTypes().contains( getType() ) };
+        return wrapper == null ? null : new Object[] { wrapper.getType().equals( type ) || wrapper.getAdditionalTypes().contains( type ) };
     }
 
     /**


### PR DESCRIPTION
Fixes #1001. The problem was actually in the modem method `hasTypeRemote`. It looks like a simple typo snuck in and the modem was checking additional types against it's own type rather than the queried type.
