### PR TITLE
Fix large file uploads producing oversized packets.

### DIFF
--- a/src/main/java/dan200/computercraft/shared/network/server/UploadFileMessage.java
+++ b/src/main/java/dan200/computercraft/shared/network/server/UploadFileMessage.java
@@ -160,6 +160,7 @@ public class UploadFileMessage extends ComputerServerMessage
                 contents.position( currentOffset ).limit( currentOffset + canWrite );
                 slices.add( new FileSlice( fileId, currentOffset, contents.slice() ) );
                 currentOffset += canWrite;
+                remaining -= canWrite;
             }
 
             contents.position( 0 ).limit( capacity );


### PR DESCRIPTION
In `UploadFileMessage.send` ...
```java
...
    if( remaining <= 0 )
    {
        NetworkHandler.sendToServer( first
            ? new UploadFileMessage( instanceId, uuid, FLAG_FIRST, files, new ArrayList<>( slices ) )
            : new UploadFileMessage( instanceId, uuid, 0, null, new ArrayList<>( slices ) ) );
        slices.clear();
        remaining = MAX_PACKET_SIZE;
        first = false;
    }
...
```
... this block that splits off smaller packets was unreachable because `remaining` wasn't being decremented. So, file slices _were_ being created according to `MAX_PACKET_SIZE`, but all slices were being put into a single fat packet.

I added a line to decrement `remaining` as file slices are created and it fixed the issue. I thought there would be some knock on effects to fixing this since it looks like file uploads were never successfully split across packets, but everything else appears to work great :)
