### PR TITLE
Add note about special JSON values in docs for `textutils.unserializeJSON`

### DIFF
--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -658,6 +658,9 @@ do
     -- This may be used with @{textutils.serializeJSON}, or when communicating
     -- with command blocks or web APIs.
     --
+    -- If a `null` value is encountered, it is converted into @{textutils.json_null}.
+    -- If an empty array is encountered, it is converted into @{textutils.empty_json_array}.
+    --
     -- @tparam string s The serialised string to deserialise.
     -- @tparam[opt] { nbt_style? = boolean, parse_null? = boolean } options
     -- Options which control how this JSON object is parsed.

--- a/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/textutils.lua
@@ -675,6 +675,8 @@ do
     -- @treturn[2] nil If the object could not be deserialised.
     -- @treturn string A message describing why the JSON string is invalid.
     -- @since 1.87.0
+    -- @see textutils.json_null Use to serialize a JSON `null` value.
+    -- @see textutils.empty_json_array Use to serialize a JSON empty array.
     unserialise_json = function(s, options)
         expect(1, s, "string")
         expect(2, options, "table", "nil")
@@ -788,6 +790,8 @@ unserialise = unserialize -- GB version
 -- times.
 -- @usage textutils.serializeJSON({ values = { 1, "2", true } })
 -- @since 1.7
+-- @see textutils.json_null Use to serialize a JSON `null` value.
+-- @see textutils.empty_json_array Use to serialize a JSON empty array.
 function serializeJSON(t, bNBTStyle)
     expect(1, t, "table", "string", "number", "boolean")
     expect(2, bNBTStyle, "boolean", "nil")


### PR DESCRIPTION
This PR adds a quick blurb noting that `textutils.unserializeJSON` returns special values for `null` and `[]`.