### PR TITLE
[1.18.x] fallback to sided cabability access if no internal access is supported

### DIFF
--- a/src/main/java/dan200/computercraft/shared/peripheral/generic/GenericPeripheralProvider.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/generic/GenericPeripheralProvider.java
@@ -46,6 +46,10 @@ public class GenericPeripheralProvider
         for( Capability<?> capability : capabilities )
         {
             LazyOptional<?> wrapper = tile.getCapability( capability );
+            if(!wrapper.isPresent())
+            {
+                wrapper = tile.getCapability( capability, side );//if no internal acccss/null side is supported try with side to increase compatibility
+            }
             wrapper.ifPresent( contents -> {
                 List<NamedMethod<PeripheralMethod>> capabilityMethods = PeripheralMethod.GENERATOR.getMethods( contents.getClass() );
                 if( capabilityMethods.isEmpty() ) return;


### PR DESCRIPTION
This adresses #1061

This adds a sided cabaility acces for generic capabilities if no nullside (internal access) is supported.
