### PR TITLE
Add documentation on full list of 5.2/5.3 features

### DIFF
--- a/doc/events/mouse_click.md
+++ b/doc/events/mouse_click.md
@@ -15,13 +15,11 @@ advanced turtles and pocket computers).
 Several mouse events (@{mouse_click}, @{mouse_up}, @{mouse_scroll}) contain a "mouse button" code. This takes a
 numerical value depending on which button on your mouse was last pressed when this event occurred.
 
-<table class="pretty-table">
-    <!-- Our markdown parser doesn't work on tables!? Guess I'll have to roll my own soonish :/. -->
-    <tr><th>Button code</th><th>Mouse button</th></tr>
-    <tr><td align="right">1</td><td>Left button</td></tr>
-    <tr><td align="right">2</td><td>Right button</td></tr>
-    <tr><td align="right">3</td><td>Middle button</td></tr>
-</table>
+| Button Code | Mouse Button  |
+|------------:|---------------|
+|           1 | Left button   |
+|           2 | Right button  |
+|           3 | Middle button |
 
 ## Example
 Print the button and the coordinates whenever the mouse is clicked.

--- a/doc/guides/feature_compat.md
+++ b/doc/guides/feature_compat.md
@@ -9,10 +9,10 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 | Feature | Supported? | Notes |
 |---------|------------|-------|
 | `goto`/labels | :x: |  |
+| `_ENV` | :large_orange_diamond: | The `_ENV` global points to `getfenv()`, but it cannot be set. |
 | `\z` escape | :heavy_check_mark: |  |
 | `\xNN` escape | :heavy_check_mark: |  |
 | hex literal fractional/exponent parts | :heavy_check_mark: |  |
-| `_ENV` | :large_orange_diamond: | The `_ENV` global points to `getfenv()`, but it cannot be set. |
 | empty statements | :x: |  |
 | `__len` metamethod | :heavy_check_mark: |  |
 | `__ipairs` metamethod | :x: |  |
@@ -20,7 +20,7 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 | `bit32` library | :heavy_check_mark: | Replaces `bit` library, which is still available for compatibility. |
 | `collectgarbage` isrunning, generational, incremental options | :x: | `collectgarbage` does not exist in CC:T. |
 | new `load` syntax | :heavy_check_mark: |  |
-| `loadfile` mode parameter | :heavy_check_mark: |  |
+| `loadfile` mode parameter | :heavy_check_mark: | Supports both 5.1 and 5.2+ syntax. |
 | removed `loadstring` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
 | removed `getfenv`, `setfenv` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
 | `rawlen` function | :heavy_check_mark: |  |
@@ -86,9 +86,9 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 ## Lua 5.0
 | Feature | Supported? | Notes |
 |---------|------------|-------|
-| `arg` table | :heavy_check_mark: |  |
+| `arg` table | :heavy_check_mark: | Only set in the shell - not used in functions. |
 | `string.gfind` | :heavy_check_mark: | Equal to `string.gmatch`. |
-| `table.getn` | :heavy_check_mark: |  |
+| `table.getn` | :heavy_check_mark: | Equal to `#tbl`. |
 | `table.setn` | :x: |  |
 | `math.mod` | :heavy_check_mark: | Equal to `math.fmod`. |
 | `table.foreach`/`table.foreachi` | :heavy_check_mark: |  |

--- a/doc/guides/feature_compat.md
+++ b/doc/guides/feature_compat.md
@@ -1,0 +1,95 @@
+---
+module: [kind=guide] feature_compat
+---
+
+# Lua 5.2/5.3 features in CC: Tweaked
+CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However, Cobalt and CC:T implement additional features from Lua 5.2 and 5.3 (as well as some deprecated 5.0 features) that are not available in base 5.1. This page lists all of the compatibility for these newer versions.
+
+## Lua 5.2
+| Feature | Supported? | Notes |
+|---------|------------|-------|
+| `goto`/labels | :x: |  |
+| `\z` escape | :heavy_check_mark: |  |
+| `\xNN` escape | :heavy_check_mark: |  |
+| hex literal fractional/exponent parts | :heavy_check_mark: |  |
+| `_ENV` | :large_orange_diamond: | The `_ENV` global points to `getfenv()`, but it cannot be set. |
+| empty statements | :x: |  |
+| `__len` metamethod | :heavy_check_mark: |  |
+| `__ipairs` metamethod | :x: |  |
+| `__pairs` metamethod | :heavy_check_mark: |  |
+| `bit32` library | :heavy_check_mark: | Replaces `bit` library, which is still available for compatibility. |
+| `collectgarbage` isrunning, generational, incremental options | :x: | `collectgarbage` does not exist in CC:T. |
+| new `load` syntax | :heavy_check_mark: |  |
+| `loadfile` mode parameter | :heavy_check_mark: |  |
+| removed `loadstring` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
+| removed `getfenv`, `setfenv` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
+| `rawlen` function | :heavy_check_mark: |  |
+| negative index to `select` | :heavy_check_mark: |  |
+| removed `unpack` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
+| arguments to `xpcall` | :x: |  |
+| second return value from `coroutine.running` | :x: |  |
+| removed `module` | :heavy_check_mark: |  |
+| `package.loaders` -> `package.searchers` | :x: |  |
+| second argument to loader functions | :heavy_check_mark: |  |
+| `package.config` | :heavy_check_mark: |  |
+| `package.searchpath` | :heavy_check_mark: |  |
+| removed `package.seeall` | :heavy_check_mark: |  |
+| `string.dump` on functions with upvalues (blanks them out) | :heavy_check_mark: |  |
+| `string.rep` separator | :x: |  |
+| `%g` match group | :x: |  |
+| removal of `%z` match group | :x: |  |
+| removed `table.maxn` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
+| `table.pack`/`table.unpack` | :heavy_check_mark: |  |
+| `math.log` base argument | :heavy_check_mark: |  |
+| removed `math.log10` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
+| `*L` mode to `file:read` | :heavy_check_mark: |  |
+| `os.execute` exit type + return value | :x: | `os.execute` does not exist in CC:T. |
+| `os.exit` close argument | :x: | `os.exit` does not exist in CC:T. |
+| `istailcall` field in `debug.getinfo` | :x: |  |
+| `nparams` field in `debug.getinfo` | :heavy_check_mark: |  |
+| `isvararg` field in `debug.getinfo` | :heavy_check_mark: |  |
+| `debug.getlocal` negative indices for varargs | :x: |  |
+| `debug.getuservalue`/`debug.setuservalue` | :x: | Userdata are rarely used in CC:T, so this is not necessary. |
+| `debug.upvalueid` | :heavy_check_mark: |  |
+| `debug.upvaluejoin` | :heavy_check_mark: |  |
+| tail call hooks | :x: |  |
+| `=` prefix for chunks | :heavy_check_mark: |  |
+| yield across C boundary | :heavy_check_mark: |  |
+| removal of ambiguity error | :x: |  |
+| identifiers may no longer use locale-dependent letters | :heavy_check_mark: |  |
+| ephemeron tables | :x: | Weak tables are not supported. |
+| functions may be reused | :x: |  |
+| generational garbage collector | :x: | Cobalt uses the built-in Java garbage collector. |
+
+## Lua 5.3
+| Feature | Supported? | Notes |
+|---------|------------|-------|
+| integer subtype | :x: |  |
+| bitwise operators/floor division | :x: |  |
+| `\u{XXX}` escape sequence | :heavy_check_mark: |  |
+| `utf8` library | :heavy_check_mark: |  |
+| removed `__ipairs` metamethod | :heavy_check_mark: |  |
+| `coroutine.isyieldable` | :x: |  |
+| `string.dump` strip argument | :heavy_check_mark: |  |
+| `string.pack`/`string.unpack`/`string.packsize` | :heavy_check_mark: |  |
+| `table.move` | :x: |  |
+| `math.atan2` -> `math.atan` | :x: |  |
+| removed `math.frexp`, `math.ldexp`, `math.pow`, `math.cosh`, `math.sinh`, `math.tanh` | :x: |  |
+| `math.maxinteger`/`math.mininteger` | :x: |  |
+| `math.tointeger` | :x: |  |
+| `math.type` | :x: |  |
+| `math.ult` | :x: |  |
+| removed `bit32` library | :x: |  |
+| remove `*` from `file:read` modes | :heavy_check_mark: |  |
+| metamethods respected in `table.*`, `ipairs` | :heavy_check_mark: |  |
+
+## Lua 5.0
+| Feature | Supported? | Notes |
+|---------|------------|-------|
+| `arg` table | :heavy_check_mark: |  |
+| `string.gfind` | :heavy_check_mark: | Equal to `string.gmatch`. |
+| `table.getn` | :heavy_check_mark: |  |
+| `table.setn` | :x: |  |
+| `math.mod` | :heavy_check_mark: | Equal to `math.fmod`. |
+| `table.foreach`/`table.foreachi` | :heavy_check_mark: |  |
+| `gcinfo` | :x: | Cobalt uses the built-in Java garbage collector. |

--- a/doc/guides/feature_compat.md
+++ b/doc/guides/feature_compat.md
@@ -6,90 +6,90 @@ module: [kind=guide] feature_compat
 CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However, Cobalt and CC:T implement additional features from Lua 5.2 and 5.3 (as well as some deprecated 5.0 features) that are not available in base 5.1. This page lists all of the compatibility for these newer versions.
 
 ## Lua 5.2
-| Feature | Supported? | Notes |
-|---------|------------|-------|
-| `goto`/labels | :x: |  |
-| `_ENV` | :large_orange_diamond: | The `_ENV` global points to `getfenv()`, but it cannot be set. |
-| `\z` escape | :heavy_check_mark: |  |
-| `\xNN` escape | :heavy_check_mark: |  |
-| hex literal fractional/exponent parts | :heavy_check_mark: |  |
-| empty statements | :x: |  |
-| `__len` metamethod | :heavy_check_mark: |  |
-| `__ipairs` metamethod | :x: |  |
-| `__pairs` metamethod | :heavy_check_mark: |  |
-| `bit32` library | :heavy_check_mark: |  |
-| `collectgarbage` isrunning, generational, incremental options | :x: | `collectgarbage` does not exist in CC:T. |
-| new `load` syntax | :heavy_check_mark: |  |
-| `loadfile` mode parameter | :heavy_check_mark: | Supports both 5.1 and 5.2+ syntax. |
-| removed `loadstring` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
-| removed `getfenv`, `setfenv` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
-| `rawlen` function | :heavy_check_mark: |  |
-| negative index to `select` | :heavy_check_mark: |  |
-| removed `unpack` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
-| arguments to `xpcall` | :x: |  |
-| second return value from `coroutine.running` | :x: |  |
-| removed `module` | :heavy_check_mark: |  |
-| `package.loaders` -> `package.searchers` | :x: |  |
-| second argument to loader functions | :heavy_check_mark: |  |
-| `package.config` | :heavy_check_mark: |  |
-| `package.searchpath` | :heavy_check_mark: |  |
-| removed `package.seeall` | :heavy_check_mark: |  |
-| `string.dump` on functions with upvalues (blanks them out) | :heavy_check_mark: |  |
-| `string.rep` separator | :x: |  |
-| `%g` match group | :x: |  |
-| removal of `%z` match group | :x: |  |
-| removed `table.maxn` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
-| `table.pack`/`table.unpack` | :heavy_check_mark: |  |
-| `math.log` base argument | :heavy_check_mark: |  |
-| removed `math.log10` | :large_orange_diamond: | Only if `disable_lua51_features` is enabled in the configuration. |
-| `*L` mode to `file:read` | :heavy_check_mark: |  |
-| `os.execute` exit type + return value | :x: | `os.execute` does not exist in CC:T. |
-| `os.exit` close argument | :x: | `os.exit` does not exist in CC:T. |
-| `istailcall` field in `debug.getinfo` | :x: |  |
-| `nparams` field in `debug.getinfo` | :heavy_check_mark: |  |
-| `isvararg` field in `debug.getinfo` | :heavy_check_mark: |  |
-| `debug.getlocal` negative indices for varargs | :x: |  |
-| `debug.getuservalue`/`debug.setuservalue` | :x: | Userdata are rarely used in CC:T, so this is not necessary. |
-| `debug.upvalueid` | :heavy_check_mark: |  |
-| `debug.upvaluejoin` | :heavy_check_mark: |  |
-| tail call hooks | :x: |  |
-| `=` prefix for chunks | :heavy_check_mark: |  |
-| yield across C boundary | :heavy_check_mark: |  |
-| removal of ambiguity error | :x: |  |
-| identifiers may no longer use locale-dependent letters | :heavy_check_mark: |  |
-| ephemeron tables | :x: |  |
-| identical functions may be reused | :x: |  |
-| generational garbage collector | :x: | Cobalt uses the built-in Java garbage collector. |
+| Feature                                                       | Supported? | Notes                                                             |
+|---------------------------------------------------------------|------------|-------------------------------------------------------------------|
+| `goto`/labels                                                 | ❌         |                                                                   |
+| `_ENV`                                                        | 🔶         | The `_ENV` global points to `getfenv()`, but it cannot be set.    |
+| `\z` escape                                                   | ✔          |                                                                   |
+| `\xNN` escape                                                 | ✔          |                                                                   |
+| Hex literal fractional/exponent parts                         | ✔          |                                                                   |
+| Empty statements                                              | ❌         |                                                                   |
+| `__len` metamethod                                            | ✔          |                                                                   |
+| `__ipairs` metamethod                                         | ❌         |                                                                   |
+| `__pairs` metamethod                                          | ✔          |                                                                   |
+| `bit32` library                                               | ✔          |                                                                   |
+| `collectgarbage` isrunning, generational, incremental options | ❌         | `collectgarbage` does not exist in CC:T.                          |
+| New `load` syntax                                             | ✔          |                                                                   |
+| `loadfile` mode parameter                                     | ✔          | Supports both 5.1 and 5.2+ syntax.                                |
+| Removed `loadstring`                                          | 🔶         | Only if `disable_lua51_features` is enabled in the configuration. |
+| Removed `getfenv`, `setfenv`                                  | 🔶         | Only if `disable_lua51_features` is enabled in the configuration. |
+| `rawlen` function                                             | ✔          |                                                                   |
+| Negative index to `select`                                    | ✔          |                                                                   |
+| Removed `unpack`                                              | 🔶         | Only if `disable_lua51_features` is enabled in the configuration. |
+| Arguments to `xpcall`                                         | ❌         |                                                                   |
+| Second return value from `coroutine.running`                  | ❌         |                                                                   |
+| Removed `module`                                              | ✔          |                                                                   |
+| `package.loaders` -> `package.searchers`                      | ❌         |                                                                   |
+| Second argument to loader functions                           | ✔          |                                                                   |
+| `package.config`                                              | ✔          |                                                                   |
+| `package.searchpath`                                          | ✔          |                                                                   |
+| Removed `package.seeall`                                      | ✔          |                                                                   |
+| `string.dump` on functions with upvalues (blanks them out)    | ✔          |                                                                   |
+| `string.rep` separator                                        | ❌         |                                                                   |
+| `%g` match group                                              | ❌         |                                                                   |
+| Removal of `%z` match group                                   | ❌         |                                                                   |
+| Removed `table.maxn`                                          | 🔶         | Only if `disable_lua51_features` is enabled in the configuration. |
+| `table.pack`/`table.unpack`                                   | ✔          |                                                                   |
+| `math.log` base argument                                      | ✔          |                                                                   |
+| Removed `math.log10`                                          | 🔶         | Only if `disable_lua51_features` is enabled in the configuration. |
+| `*L` mode to `file:read`                                      | ✔          |                                                                   |
+| `os.execute` exit type + return value                         | ❌         | `os.execute` does not exist in CC:T.                              |
+| `os.exit` close argument                                      | ❌         | `os.exit` does not exist in CC:T.                                 |
+| `istailcall` field in `debug.getinfo`                         | ❌         |                                                                   |
+| `nparams` field in `debug.getinfo`                            | ✔          |                                                                   |
+| `isvararg` field in `debug.getinfo`                           | ✔          |                                                                   |
+| `debug.getlocal` negative indices for varargs                 | ❌         |                                                                   |
+| `debug.getuservalue`/`debug.setuservalue`                     | ❌         | Userdata are rarely used in CC:T, so this is not necessary.       |
+| `debug.upvalueid`                                             | ✔          |                                                                   |
+| `debug.upvaluejoin`                                           | ✔          |                                                                   |
+| Tail call hooks                                               | ❌         |                                                                   |
+| `=` prefix for chunks                                         | ✔          |                                                                   |
+| Yield across C boundary                                       | ✔          |                                                                   |
+| Removal of ambiguity error                                    | ❌         |                                                                   |
+| Identifiers may no longer use locale-dependent letters        | ✔          |                                                                   |
+| Ephemeron tables                                              | ❌         |                                                                   |
+| Identical functions may be reused                             | ❌         |                                                                   |
+| Generational garbage collector                                | ❌         | Cobalt uses the built-in Java garbage collector.                  |
 
 ## Lua 5.3
-| Feature | Supported? | Notes |
-|---------|------------|-------|
-| integer subtype | :x: |  |
-| bitwise operators/floor division | :x: |  |
-| `\u{XXX}` escape sequence | :heavy_check_mark: |  |
-| `utf8` library | :heavy_check_mark: |  |
-| removed `__ipairs` metamethod | :heavy_check_mark: |  |
-| `coroutine.isyieldable` | :x: |  |
-| `string.dump` strip argument | :heavy_check_mark: |  |
-| `string.pack`/`string.unpack`/`string.packsize` | :heavy_check_mark: |  |
-| `table.move` | :x: |  |
-| `math.atan2` -> `math.atan` | :x: |  |
-| removed `math.frexp`, `math.ldexp`, `math.pow`, `math.cosh`, `math.sinh`, `math.tanh` | :x: |  |
-| `math.maxinteger`/`math.mininteger` | :x: |  |
-| `math.tointeger` | :x: |  |
-| `math.type` | :x: |  |
-| `math.ult` | :x: |  |
-| removed `bit32` library | :x: |  |
-| remove `*` from `file:read` modes | :heavy_check_mark: |  |
-| metamethods respected in `table.*`, `ipairs` | :large_orange_diamond: | Only `__lt` is respected. |
+| Feature                                                                               | Supported? | Notes                     |
+|---------------------------------------------------------------------------------------|------------|---------------------------|
+| Integer subtype                                                                       | ❌         |                           |
+| Bitwise operators/floor division                                                      | ❌         |                           |
+| `\u{XXX}` escape sequence                                                             | ✔          |                           |
+| `utf8` library                                                                        | ✔          |                           |
+| removed `__ipairs` metamethod                                                         | ✔          |                           |
+| `coroutine.isyieldable`                                                               | ❌         |                           |
+| `string.dump` strip argument                                                          | ✔          |                           |
+| `string.pack`/`string.unpack`/`string.packsize`                                       | ✔          |                           |
+| `table.move`                                                                          | ❌         |                           |
+| `math.atan2` -> `math.atan`                                                           | ❌         |                           |
+| Removed `math.frexp`, `math.ldexp`, `math.pow`, `math.cosh`, `math.sinh`, `math.tanh` | ❌         |                           |
+| `math.maxinteger`/`math.mininteger`                                                   | ❌         |                           |
+| `math.tointeger`                                                                      | ❌         |                           |
+| `math.type`                                                                           | ❌         |                           |
+| `math.ult`                                                                            | ❌         |                           |
+| Removed `bit32` library                                                               | ❌         |                           |
+| Remove `*` from `file:read` modes                                                     | ✔          |                           |
+| Metamethods respected in `table.*`, `ipairs`                                          | 🔶         | Only `__lt` is respected. |
 
 ## Lua 5.0
-| Feature | Supported? | Notes |
-|---------|------------|-------|
-| `arg` table | :large_orange_diamond: | Only set in the shell - not used in functions. |
-| `string.gfind` | :heavy_check_mark: | Equal to `string.gmatch`. |
-| `table.getn` | :heavy_check_mark: | Equal to `#tbl`. |
-| `table.setn` | :x: |  |
-| `math.mod` | :heavy_check_mark: | Equal to `math.fmod`. |
-| `table.foreach`/`table.foreachi` | :heavy_check_mark: |  |
-| `gcinfo` | :x: | Cobalt uses the built-in Java garbage collector. |
+| Feature                          | Supported? | Notes                                            |
+|----------------------------------|------------|--------------------------------------------------|
+| `arg` table                      | 🔶         | Only set in the shell - not used in functions.   |
+| `string.gfind`                   | ✔          | Equal to `string.gmatch`.                        |
+| `table.getn`                     | ✔          | Equal to `#tbl`.                                 |
+| `table.setn`                     | ❌         |                                                  |
+| `math.mod`                       | ✔          | Equal to `math.fmod`.                            |
+| `table.foreach`/`table.foreachi` | ✔          |                                                  |
+| `gcinfo`                         | ❌         | Cobalt uses the built-in Java garbage collector. |

--- a/doc/guides/feature_compat.md
+++ b/doc/guides/feature_compat.md
@@ -17,7 +17,7 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 | `__len` metamethod | :heavy_check_mark: |  |
 | `__ipairs` metamethod | :x: |  |
 | `__pairs` metamethod | :heavy_check_mark: |  |
-| `bit32` library | :heavy_check_mark: | Replaces `bit` library, which is still available for compatibility. |
+| `bit32` library | :heavy_check_mark: |  |
 | `collectgarbage` isrunning, generational, incremental options | :x: | `collectgarbage` does not exist in CC:T. |
 | new `load` syntax | :heavy_check_mark: |  |
 | `loadfile` mode parameter | :heavy_check_mark: | Supports both 5.1 and 5.2+ syntax. |
@@ -57,8 +57,8 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 | yield across C boundary | :heavy_check_mark: |  |
 | removal of ambiguity error | :x: |  |
 | identifiers may no longer use locale-dependent letters | :heavy_check_mark: |  |
-| ephemeron tables | :x: | Weak tables are not supported. |
-| functions may be reused | :x: |  |
+| ephemeron tables | :x: |  |
+| identical functions may be reused | :x: |  |
 | generational garbage collector | :x: | Cobalt uses the built-in Java garbage collector. |
 
 ## Lua 5.3
@@ -81,12 +81,12 @@ CC: Tweaked is based off of the Cobalt Lua runtime, which uses Lua 5.1. However,
 | `math.ult` | :x: |  |
 | removed `bit32` library | :x: |  |
 | remove `*` from `file:read` modes | :heavy_check_mark: |  |
-| metamethods respected in `table.*`, `ipairs` | :heavy_check_mark: |  |
+| metamethods respected in `table.*`, `ipairs` | :large_orange_diamond: | Only `__lt` is respected. |
 
 ## Lua 5.0
 | Feature | Supported? | Notes |
 |---------|------------|-------|
-| `arg` table | :heavy_check_mark: | Only set in the shell - not used in functions. |
+| `arg` table | :large_orange_diamond: | Only set in the shell - not used in functions. |
 | `string.gfind` | :heavy_check_mark: | Equal to `string.gmatch`. |
 | `table.getn` | :heavy_check_mark: | Equal to `#tbl`. |
 | `table.setn` | :x: |  |

--- a/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -16,7 +16,7 @@ terminal supports color by using the function @{term.isColor}.
 Grayscale colors are calculated by taking the average of the three components,
 i.e. `(red + green + blue) / 3`.
 
-<table class="pretty-table">
+<table style="display: block">
 <thead>
     <tr><th colspan="8" align="center">Default Colors</th></tr>
     <tr>

--- a/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
+++ b/src/main/resources/data/computercraft/lua/rom/apis/colors.lua
@@ -16,7 +16,7 @@ terminal supports color by using the function @{term.isColor}.
 Grayscale colors are calculated by taking the average of the three components,
 i.e. `(red + green + blue) / 3`.
 
-<table style="display: block">
+<table>
 <thead>
     <tr><th colspan="8" align="center">Default Colors</th></tr>
     <tr>

--- a/src/web/styles.css
+++ b/src/web/styles.css
@@ -7,17 +7,17 @@
 }
 
 /* Pretty tables, mostly inherited from table.definition-list */
-table.pretty-table {
+table {
     border-collapse: collapse;
     width: 100%;
 }
 
-table.pretty-table td, table.pretty-table th {
+table td, table th {
     border: 1px solid #cccccc;
     padding: 2px 4px;
 }
 
-table.pretty-table th {
+table th {
     background-color: var(--background-2);
 }
 


### PR DESCRIPTION
This PR adds a new page of documentation on exactly which features in Lua 5.2/5.3 (as well as old 5.0 functions) are available in CC:T.
