### PR TITLE
[1.16] Make blocks rotatable for structures

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,5 +4,5 @@ mod_version=1.100.5
 # Minecraft properties (update mods.toml when changing)
 mc_version=1.16.5
 mapping_version=2021.08.08
-forge_version=36.2.20
+forge_version=36.2.34
 # NO SERIOUSLY, UPDATE mods.toml WHEN CHANGING

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
@@ -52,16 +52,20 @@ public class BlockComputer extends BlockComputerBase<TileComputer>
         return defaultBlockState().setValue( FACING, placement.getHorizontalDirection().getOpposite() );
     }
 
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    @Nonnull
+    @Override
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
+
     @Nonnull
     @Override
     protected ItemStack getItem( TileComputerBase tile )

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
@@ -18,6 +18,7 @@ import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Mirror;
 import net.minecraftforge.fml.RegistryObject;
 
 import javax.annotation.Nonnull;
@@ -48,6 +49,12 @@ public class BlockComputer extends BlockComputerBase<TileComputer>
     public BlockState getStateForPlacement( BlockItemUseContext placement )
     {
         return defaultBlockState().setValue( FACING, placement.getHorizontalDirection().getOpposite() );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
@@ -10,8 +10,6 @@ import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.items.ComputerItemFactory;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
-import net.minecraft.block.FurnaceBlock;
-import net.minecraft.block.StairsBlock;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.DirectionProperty;

--- a/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
+++ b/src/main/java/dan200/computercraft/shared/computer/blocks/BlockComputer.java
@@ -10,6 +10,8 @@ import dan200.computercraft.shared.computer.core.ComputerState;
 import dan200.computercraft.shared.computer.items.ComputerItemFactory;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.FurnaceBlock;
+import net.minecraft.block.StairsBlock;
 import net.minecraft.item.BlockItemUseContext;
 import net.minecraft.item.ItemStack;
 import net.minecraft.state.DirectionProperty;
@@ -19,6 +21,7 @@ import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraftforge.fml.RegistryObject;
 
 import javax.annotation.Nonnull;
@@ -57,6 +60,10 @@ public class BlockComputer extends BlockComputerBase<TileComputer>
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+    }
     @Nonnull
     @Override
     protected ItemStack getItem( TileComputerBase tile )

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
@@ -25,7 +25,6 @@ import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -50,19 +49,20 @@ public class BlockDiskDrive extends BlockGeneric
         properties.add( FACING, STATE );
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
+
     @Nullable
     @Override
     public BlockState getStateForPlacement( BlockItemUseContext placement )

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
@@ -22,8 +22,10 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.INameable;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -48,12 +50,19 @@ public class BlockDiskDrive extends BlockGeneric
         properties.add( FACING, STATE );
     }
 
+    @NotNull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
+    @NotNull
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+    }
     @Nullable
     @Override
     public BlockState getStateForPlacement( BlockItemUseContext placement )

--- a/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/diskdrive/BlockDiskDrive.java
@@ -21,6 +21,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.INameable;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -45,6 +46,12 @@ public class BlockDiskDrive extends BlockGeneric
     protected void createBlockStateDefinition( StateContainer.Builder<Block, BlockState> properties )
     {
         properties.add( FACING, STATE );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
@@ -18,6 +18,7 @@ import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -93,5 +94,11 @@ public class BlockWirelessModem extends BlockGeneric implements IWaterLoggable
         return defaultBlockState()
             .setValue( FACING, placement.getClickedFace().getOpposite() )
             .setValue( WATERLOGGED, getWaterloggedStateForPlacement( placement ) );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
@@ -19,6 +19,7 @@ import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -26,6 +27,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraftforge.fml.RegistryObject;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -96,9 +98,17 @@ public class BlockWirelessModem extends BlockGeneric implements IWaterLoggable
             .setValue( WATERLOGGED, getWaterloggedStateForPlacement( placement ) );
     }
 
+    @NotNull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
+    }
+
+    @NotNull
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/modem/wireless/BlockWirelessModem.java
@@ -27,7 +27,6 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.IWorldReader;
 import net.minecraftforge.fml.RegistryObject;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -98,17 +97,17 @@ public class BlockWirelessModem extends BlockGeneric implements IWaterLoggable
             .setValue( WATERLOGGED, getWaterloggedStateForPlacement( placement ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
 }

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
@@ -24,7 +24,6 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.RegistryObject;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -54,18 +53,18 @@ public class BlockMonitor extends BlockGeneric
         builder.add( ORIENTATION, FACING, STATE );
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
@@ -18,6 +18,7 @@ import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
@@ -49,6 +50,12 @@ public class BlockMonitor extends BlockGeneric
     protected void createBlockStateDefinition( StateContainer.Builder<Block, BlockState> builder )
     {
         builder.add( ORIENTATION, FACING, STATE );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/monitor/BlockMonitor.java
@@ -19,10 +19,12 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.FakePlayer;
 import net.minecraftforge.fml.RegistryObject;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -52,10 +54,18 @@ public class BlockMonitor extends BlockGeneric
         builder.add( ORIENTATION, FACING, STATE );
     }
 
+    @NotNull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
+    }
+
+    @NotNull
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
     }
 
     @Override

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
@@ -21,6 +21,7 @@ import net.minecraft.stats.Stats;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.INameable;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -46,6 +47,12 @@ public class BlockPrinter extends BlockGeneric
     protected void createBlockStateDefinition( StateContainer.Builder<Block, BlockState> properties )
     {
         properties.add( FACING, TOP, BOTTOM );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
@@ -22,6 +22,7 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.Direction;
 import net.minecraft.util.INameable;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
@@ -53,6 +54,12 @@ public class BlockPrinter extends BlockGeneric
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
+    }
+
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/printer/BlockPrinter.java
@@ -50,16 +50,18 @@ public class BlockPrinter extends BlockGeneric
         properties.add( FACING, TOP, BOTTOM );
     }
 
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
@@ -14,6 +14,7 @@ import net.minecraft.state.DirectionProperty;
 import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Mirror;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +33,12 @@ public class BlockSpeaker extends BlockGeneric
     protected void createBlockStateDefinition( StateContainer.Builder<Block, BlockState> properties )
     {
         properties.add( FACING );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
@@ -15,6 +15,8 @@ import net.minecraft.state.StateContainer;
 import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
+import net.minecraft.util.Rotation;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nullable;
 
@@ -35,10 +37,18 @@ public class BlockSpeaker extends BlockGeneric
         properties.add( FACING );
     }
 
+    @NotNull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
+    }
+
+    @NotNull
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
+++ b/src/main/java/dan200/computercraft/shared/peripheral/speaker/BlockSpeaker.java
@@ -16,8 +16,8 @@ import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.Rotation;
-import org.jetbrains.annotations.NotNull;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class BlockSpeaker extends BlockGeneric
@@ -37,18 +37,18 @@ public class BlockSpeaker extends BlockGeneric
         properties.add( FACING );
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
 
     @Nullable

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
@@ -29,6 +29,7 @@ import net.minecraft.state.properties.BlockStateProperties;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
+import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
@@ -69,6 +70,12 @@ public class BlockTurtle extends BlockComputerBase<TileTurtle> implements IWater
     protected void createBlockStateDefinition( StateContainer.Builder<Block, BlockState> builder )
     {
         builder.add( FACING, WATERLOGGED );
+    }
+
+    @Override
+    public BlockState mirror( BlockState state, Mirror mirrorIn )
+    {
+        return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
@@ -9,7 +9,6 @@ import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.shared.computer.blocks.BlockComputerBase;
 import dan200.computercraft.shared.computer.blocks.TileComputerBase;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
-import dan200.computercraft.shared.peripheral.modem.wired.ItemBlockCable;
 import dan200.computercraft.shared.turtle.core.TurtleBrain;
 import dan200.computercraft.shared.turtle.items.ITurtleItem;
 import dan200.computercraft.shared.turtle.items.TurtleItemFactory;

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
@@ -42,7 +42,6 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.RegistryObject;
-import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -74,18 +73,18 @@ public class BlockTurtle extends BlockComputerBase<TileTurtle> implements IWater
         builder.add( FACING, WATERLOGGED );
     }
 
-    @NotNull
+    @Nonnull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
     }
 
-    @NotNull
+    @Nonnull
     @Override
-    public BlockState rotate( BlockState pState, Rotation pRot )
+    public BlockState rotate( BlockState state, Rotation rot )
     {
-        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
+        return state.setValue( FACING, rot.rotate( state.getValue( FACING ) ) );
     }
 
     @Nonnull

--- a/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
+++ b/src/main/java/dan200/computercraft/shared/turtle/blocks/BlockTurtle.java
@@ -9,6 +9,7 @@ import dan200.computercraft.api.turtle.TurtleSide;
 import dan200.computercraft.shared.computer.blocks.BlockComputerBase;
 import dan200.computercraft.shared.computer.blocks.TileComputerBase;
 import dan200.computercraft.shared.computer.core.ComputerFamily;
+import dan200.computercraft.shared.peripheral.modem.wired.ItemBlockCable;
 import dan200.computercraft.shared.turtle.core.TurtleBrain;
 import dan200.computercraft.shared.turtle.items.ITurtleItem;
 import dan200.computercraft.shared.turtle.items.TurtleItemFactory;
@@ -31,6 +32,7 @@ import net.minecraft.tileentity.TileEntityType;
 import net.minecraft.util.Direction;
 import net.minecraft.util.Mirror;
 import net.minecraft.util.ResourceLocation;
+import net.minecraft.util.Rotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.shapes.ISelectionContext;
 import net.minecraft.util.math.shapes.VoxelShape;
@@ -41,6 +43,7 @@ import net.minecraft.world.IBlockReader;
 import net.minecraft.world.IWorld;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.RegistryObject;
+import org.jetbrains.annotations.NotNull;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -72,10 +75,18 @@ public class BlockTurtle extends BlockComputerBase<TileTurtle> implements IWater
         builder.add( FACING, WATERLOGGED );
     }
 
+    @NotNull
     @Override
     public BlockState mirror( BlockState state, Mirror mirrorIn )
     {
         return state.rotate( mirrorIn.getRotation( state.getValue( FACING ) ) );
+    }
+
+    @NotNull
+    @Override
+    public BlockState rotate( BlockState pState, Rotation pRot )
+    {
+        return pState.setValue( FACING, pRot.rotate( pState.getValue( FACING ) ) );
     }
 
     @Nonnull

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -20,6 +20,6 @@ CC: Tweaked is a fork of ComputerCraft, adding programmable computers, turtles a
 [[dependencies.computercraft]]
     modId="forge"
     mandatory=true
-    versionRange="[36.2.20,37)"
+    versionRange="[36.2.34,37)"
     ordering="NONE"
     side="BOTH"


### PR DESCRIPTION
For further explanation, see #1082 
Every block should now be rotatable for structures. If you see that I missed one, just tell me (:
I also updated forge so that it supports newer versions of java

I'll open a PR for 1.18 in the next days