### PR TITLE
changelog: document sleep()'s optional parameter, starting in 1.63

### DIFF
--- a/doc/stub/global.lua
+++ b/doc/stub/global.lua
@@ -37,6 +37,8 @@ nearest multiple of 0.05.
     print("Sleeping for three seconds")
     sleep(3)
     print("Done!")
+
+@changed 1.63 The `time` parameter is now optional, defaulting to 0 if not set.
 ]]
 function sleep(time) end
 

--- a/doc/stub/global.lua
+++ b/doc/stub/global.lua
@@ -28,7 +28,7 @@ thread, not the whole program.
 > need to receive events while sleeping, consider using [timers][`os.startTimer`],
 > or the [parallel API][`parallel`].
 
-@tparam number time The number of seconds to sleep for, rounded up to the
+@tparam[opt=0] number time The number of seconds to sleep for, rounded up to the
 nearest multiple of 0.05.
 
 @see os.startTimer
@@ -38,7 +38,7 @@ nearest multiple of 0.05.
     sleep(3)
     print("Done!")
 
-@changed 1.63 The `time` parameter is now optional, defaulting to 0 if not set.
+@changed 1.63 The `time` parameter is now optional.
 ]]
 function sleep(time) end
 

--- a/doc/stub/os.lua
+++ b/doc/stub/os.lua
@@ -91,8 +91,8 @@ function pullEventRaw(filter) end
 
 --- Pauses execution for the specified number of seconds, alias of [`_G.sleep`].
 --
--- @tparam number time The number of seconds to sleep for, rounded up to the
--- nearest multiple of 0.05.
+-- @tparam[opt=0] number time The number of seconds to sleep for, rounded up to
+-- the nearest multiple of 0.05.
 function sleep(time) end
 
 --- Get the current CraftOS version (for example, `CraftOS 1.9`).

--- a/projects/core/src/main/resources/data/computercraft/lua/rom/help/changelog.md
+++ b/projects/core/src/main/resources/data/computercraft/lua/rom/help/changelog.md
@@ -1434,6 +1434,7 @@ And several bug fixes:
 * Turtle label nameplates now only show when the Turtle is moused-over
 * The HTTP API is now enabled by default, and can be configured with a whitelist of permitted domains
 * `http.get()` and `http.post()` now accept parameters to control the request headers
+* `sleep()`, when invoked without a parameter, defaults to 0.
 * New fs function: `fs.getDir( path )`
 * Fixed some bugs
 


### PR DESCRIPTION
Had to do some archaeology for this one! 1.62 is missing this string:

    local timer = os.startTimer( nTime or 0 )

which is only present in 1.63 and later.

## Rationale

Users of older versions (like me!) still use tweaked.cc for documentation. It's good to know what I can and can't use when playing, say, Tekkit 1.6.4[^1]

[^1]: Tekkit uses CC 1.58. Don't ask me why it doesn't use a newer version that also supports 1.6.4 like, say, CC 1.63...
