### PR TITLE
Fix random indentation of two lines in bios.lua

### DIFF
--- a/projects/core/src/main/resources/data/computercraft/lua/bios.lua
+++ b/projects/core/src/main/resources/data/computercraft/lua/bios.lua
@@ -628,12 +628,12 @@ settings.define("shell.autocomplete", {
 settings.define("edit.autocomplete", {
     default = true,
     description = "Autocomplete API and function names in the editor.",
-        type = "boolean",
+    type = "boolean",
 })
 settings.define("lua.autocomplete", {
     default = true,
     description = "Autocomplete API and function names in the Lua REPL.",
-        type = "boolean",
+    type = "boolean",
 })
 
 settings.define("edit.default_extension", {


### PR DESCRIPTION
The "type" field definitions for the "edit.autocomplete" and "lua.autocomplete" settings were both randomly indented, compared to the rest of the setting definitions.